### PR TITLE
WIP: Translate and return api errors

### DIFF
--- a/api/lib/iconSearch.js
+++ b/api/lib/iconSearch.js
@@ -1,5 +1,42 @@
 const OAuth = require('oauth')
+const { parseDocument } = require('htmlparser2')
 const translate = require('./translate')
+const { NOUN_KEY, NOUN_SECRET, ICONS_TO_DOWNLOAD } = process.env
+
+const oauth = new OAuth.OAuth(
+  'http://api.thenounproject.com',
+  'http://api.thenounproject.com',
+  NOUN_KEY,
+  NOUN_SECRET,
+  '1.0',
+  null,
+  'HMAC-SHA1'
+)
+
+const fetch = (url, locale) =>
+  new Promise((resolve) => {
+    oauth.get(url, null, null, async (e, data) => {
+      if (e) {
+        console.log('Got error on fetching', url)
+        // Parse error
+        const dom = parseDocument(e.data)
+        const messages = dom.children
+        const errorMsg = messages
+          .filter((m) => m.name === 'p')
+          .map((m) => m.children[0].data)[0]
+        e.data = errorMsg
+        if (locale && locale !== 'en') {
+          console.log('locale', locale)
+          const translated = await translate(errorMsg, 'en', locale)
+          e.data = translated
+        }
+        resolve({ error: e })
+      } else {
+        const json = JSON.parse(data)
+        resolve(json)
+      }
+    })
+  })
 
 module.exports = async (noun, locale, pagination) => {
   if (!noun || typeof noun !== 'string') throw Error
@@ -7,37 +44,15 @@ module.exports = async (noun, locale, pagination) => {
   if (locale !== 'en') translation = await translate(noun, locale)
   translation = translation.split(' ').join('%20')
   console.log(`Downloading page ${pagination} translated: ${translation}`)
-  const { NOUN_KEY, NOUN_SECRET, ICONS_TO_DOWNLOAD } = process.env
   const resLimit = parseInt(ICONS_TO_DOWNLOAD)
   const limit = typeof resLimit === 'number' ? resLimit : 3
   console.log('Number of icons to search for:', limit)
-  const oauth = new OAuth.OAuth(
-    'http://api.thenounproject.com',
-    'http://api.thenounproject.com',
-    NOUN_KEY,
-    NOUN_SECRET,
-    '1.0',
-    null,
-    'HMAC-SHA1'
-  )
-  const fetch = (url) =>
-    new Promise((resolve, reject) => {
-      oauth.get(url, null, null, (e, data) => {
-        if (e) {
-          console.log('Got error on fetching', url)
-          console.error(e)
-          reject(e)
-        } else {
-          const json = JSON.parse(data)
-          resolve(json)
-        }
-      })
-    })
   const search = await fetch(
     `https://api.thenounproject.com/icons/${translation}?limit=${limit}${
       pagination && `&page=${pagination}`
-    }`
+    }`,
+    locale
   )
-  if (!search) return false
-  return search.icons.map((icon) => icon.preview_url)
+  if (!search.error) return search.icons.map((icon) => icon.preview_url)
+  else return search
 }

--- a/api/lib/translate.js
+++ b/api/lib/translate.js
@@ -1,11 +1,14 @@
 const { translate } = require('bing-translate-api')
 
-async function runTranslate(searchTerm, locale) {
-  const translation = await translate(searchTerm, locale, 'en', true)
+async function runTranslate(searchTerm, from, to) {
+  console.log('searchTerm', searchTerm)
+  console.log('from', from)
+  console.log('to', to)
+  const translation = await translate(searchTerm, from, to || 'en', true)
   console.log('translation', translation)
   return translation.translation
 }
 
-module.exports = async (searchTerm, locale) => {
-  return await runTranslate(searchTerm, locale)
+module.exports = async (searchTerm, from) => {
+  return await runTranslate(searchTerm, from)
 }

--- a/components/Search.vue
+++ b/components/Search.vue
@@ -13,7 +13,12 @@
           <p class="mb-5">{{ $t('description') }}</p>
           <p class="mb-5">
             {{ $t('config') }}
-            <a href="https://docs.mapeo.app/complete-reference-guide/customization-options/custom-configurations/creating-custom-configurations" target="_blank" class="underline">{{ $t('link') }}</a>
+            <a
+              href="https://docs.mapeo.app/complete-reference-guide/customization-options/custom-configurations/creating-custom-configurations"
+              target="_blank"
+              class="underline"
+              >{{ $t('link') }}</a
+            >
           </p>
         </div>
       </div>
@@ -55,8 +60,8 @@ export default {
   name: 'NuxtTutorial',
   props: {
     error: {
-      type: Boolean,
-      default: false,
+      type: String || null,
+      default: null,
     },
   },
   data() {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bing-translate-api": "^2.6.0",
     "core-js": "^3.26.0",
     "express": "^4.18.2",
+    "htmlparser2": "^8.0.1",
     "mini-svg-data-uri": "^1.4.4",
     "nuxt": "^2.15.8",
     "oauth": "^0.10.0",
@@ -35,7 +36,8 @@
     "vue-color": "^2.8.1",
     "vue-server-renderer": "^2.7.13",
     "vue-template-compiler": "^2.7.13",
-    "webpack": "^4.46.0"
+    "webpack": "^4.46.0",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",

--- a/pages/images.vue
+++ b/pages/images.vue
@@ -78,8 +78,10 @@ export default Vue.extend({
     const { s, l } = query
     try {
       const response = await app.$axios.$get(`/api/search?s=${s}&l=${l}`)
+      if (response.error) return { ...response }
       return { images: response, search: s, language: l }
     } catch (err) {
+      console.error(err)
       return { err, images: null, search: s, language: l }
     }
   },
@@ -100,9 +102,9 @@ export default Vue.extend({
     },
   },
   mounted() {
-    if (this.err) {
-      let error = 'error=true'
-      if (this.err.code === 'ECONNREFUSED') error = ''
+    if (this.error) {
+      const error = `error=${this.err.data}`
+      console.log('this.err', this.err)
       this.$router.push(this.localePath(`/?${error}`))
     } else if (this.images?.length > 0) this.active = this.images[0]
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@ export default Vue.extend({
   name: 'IndexPage',
   asyncData({ query }) {
     const { error } = query
-    return { error: !!error }
+    return { error }
   },
 })
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5486,6 +5486,13 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+express-xml-bodyparser@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/express-xml-bodyparser/-/express-xml-bodyparser-0.3.0.tgz#b1f5a98adf6c6e412c4ccba634234b82945c62be"
+  integrity sha512-biHFKaZsPZQaf6H+xB8f8aawqe4c671JIF2RN8f3k9iOtPe8TVBb4H8tQkURFWFpGic53TCD5+uno9u52hdYoA==
+  dependencies:
+    xml2js "^0.4.11"
+
 express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
@@ -11932,7 +11939,7 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==
 
-xml2js@^0.4.5:
+xml2js@^0.4.11, xml2js@^0.4.23, xml2js@^0.4.5:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==


### PR DESCRIPTION
This is still WIP, but pretty close to finalizing if really worth it. Went too deep into a rabbit hole, so will pause until we settle, as there's no apparent need for it. Errors seem to only be 2 for now (?):

- "we couldn't find any icons associated with that phrase"
- "that's all the icons we could find for that phrase"

The idea is that users will get the exact error that [thenounproject api](https://api.thenounproject.com/documentation.html) is returning.

**pros:**
- we don't worry about dealing with various errors

**cons:**
- if api changes we have to update